### PR TITLE
[Add]Rspec／declutterモデルのテスト項目を追加

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/spec/factories/declutter.rb
+++ b/spec/factories/declutter.rb
@@ -1,0 +1,7 @@
+# ダミーデータの作成
+FactoryBot.define do
+  factory :declutter do
+    caption { Faker::Lorem.characters(number:200) }
+    user
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,9 @@
+# ダミーデータの作成
+FactoryBot.define do
+  factory :user do
+    name { 'test' }
+    email { Faker::Internet.email }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'support/factory_bot'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/test_models/declutter_spec.rb
+++ b/spec/test_models/declutter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Declutterモデルのテスト', type: :model do
+  describe 'バリデーションのテスト' do
+    # factoriesで作成したダミーデータを使用
+    let(:user) { FactoryBot.create(:user) }
+    let!(:declutter) { build(:declutter, user_id: user.id) }
+
+    # test_declutterを作成し、空欄での登録ができるか確認
+    subject { test_declutter.valid? }
+    let(:test_declutter) { declutter }
+
+
+    context 'titleカラム' do
+      it '空欄でないこと' do
+        test_declutter.title = ''
+        is_expected.to eq false;
+      end
+      it '10文字以下であること' do
+        declutter.title = Faker::Lorem.characters(number:11)
+        expect(declutter.valid?).to eq false;
+      end
+    end
+  end
+  describe 'アソシエーションのテスト' do
+    context 'Userモデルとの関係' do
+      it 'N:1となっている' do
+        expect(Declutter.reflect_on_association(:user).macro).to eq :belongs_to
+      end
+    end
+  end
+end


### PR DESCRIPTION
【Rspec】Declutterモデルのテスト項目を追記
・バリデーションのテスト(titleカラム：空欄でないか、10文字以下であるか)
・アソシエーションのテスト(UserモデルとN:1の関係となっているかの確認)