### PR TITLE
[Add]Rspec／declutterモデルのテスト項目を追加(アソシエーション)

### DIFF
--- a/spec/test_models/declutter_spec.rb
+++ b/spec/test_models/declutter_spec.rb
@@ -44,5 +44,20 @@ RSpec.describe 'Declutterモデルのテスト', type: :model do
         expect(Declutter.reflect_on_association(:user).macro).to eq :belongs_to
       end
     end
+    context 'Declutter_commentsモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Declutter.reflect_on_association(:declutter_comments).macro).to eq :has_many
+      end
+    end
+    context 'Likesモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Declutter.reflect_on_association(:likes).macro).to eq :has_many
+      end
+    end
+    context 'Bookmarksモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Declutter.reflect_on_association(:bookmarks).macro).to eq :has_many
+      end
+    end
   end
 end


### PR DESCRIPTION
【Rspec】テスト項目を追加
・アソシエーションのテスト(DeclutterモデルとDeclutter_comments、Likes、Bookmarksモデルが1:Nの関係となっているかを確認)